### PR TITLE
Added support for 'operation' parameter

### DIFF
--- a/lib/Ogone/AbstractPaymentRequest.php
+++ b/lib/Ogone/AbstractPaymentRequest.php
@@ -14,6 +14,11 @@ use InvalidArgumentException;
 
 abstract class AbstractPaymentRequest extends AbstractRequest
 {
+    const OPERATION_REQUEST_AUTHORIZATION = 'RES';
+    const OPERATION_REQUEST_DIRECT_SALE = 'SAL';
+    const OPERATION_REFUND = 'RFD';
+    const OPERATION_REQUEST_PRE_AUTHORIZATION = 'PAU';
+
     protected $brandsmap = array(
         'Acceptgiro' => 'Acceptgiro',
         'AIRPLUS' => 'CreditCard',
@@ -249,4 +254,14 @@ abstract class AbstractPaymentRequest extends AbstractRequest
         $this->parameters['tp'] = $tp;
     }
 
+    public function setOperation($operation)
+    {
+        if (!in_array($operation, $this->getValidOperations())) {
+            throw new InvalidArgumentException("Invalid operation [$operation].");
+        }
+
+        $this->parameters['operation'] = $operation;
+    }
+
+    abstract protected function getValidOperations();
 } 

--- a/lib/Ogone/DirectLink/DirectLinkPaymentRequest.php
+++ b/lib/Ogone/DirectLink/DirectLinkPaymentRequest.php
@@ -73,4 +73,14 @@ class DirectLinkPaymentRequest extends AbstractPaymentRequest {
     {
         $this->parameters['cvc'] = $cvc;
     }
+
+    protected function getValidOperations()
+    {
+        return array(
+            self::OPERATION_REQUEST_AUTHORIZATION,
+            self::OPERATION_REQUEST_DIRECT_SALE,
+            self::OPERATION_REFUND,
+            self::OPERATION_REQUEST_PRE_AUTHORIZATION,
+        );
+    }
 }

--- a/lib/Ogone/Ecommerce/EcommercePaymentRequest.php
+++ b/lib/Ogone/Ecommerce/EcommercePaymentRequest.php
@@ -42,4 +42,13 @@ class EcommercePaymentRequest extends AbstractPaymentRequest {
         $this->parameters['aliasusage'] = $alias->getAliasUsage();
         $this->parameters['alias'] = $alias->getAlias();
     }
+
+    protected function getValidOperations()
+    {
+        return array(
+            self::OPERATION_REQUEST_AUTHORIZATION,
+            self::OPERATION_REQUEST_DIRECT_SALE,
+            self::OPERATION_REQUEST_PRE_AUTHORIZATION,
+        );
+    }
 }

--- a/tests/Ogone/Tests/DirectLink/DirectLinkPaymentRequestTest.php
+++ b/tests/Ogone/Tests/DirectLink/DirectLinkPaymentRequestTest.php
@@ -82,6 +82,16 @@ class DirectLinkPaymentRequestTest extends \TestCase {
 
     /**
      * @test
+     */
+    public function isValidWhenOperationIsSet()
+    {
+        $directLinkPaymentRequest = $this->provideMinimalDirectLinkPaymentRequest();
+        $directLinkPaymentRequest->setOperation(DirectLinkPaymentRequest::OPERATION_REQUEST_DIRECT_SALE);
+        $directLinkPaymentRequest->validate();
+    }
+
+    /**
+     * @test
      * @dataProvider provideBadParameters
      * @expectedException \InvalidArgumentException
      */
@@ -95,7 +105,8 @@ class DirectLinkPaymentRequestTest extends \TestCase {
     {
         return array(
             array('setPswd', '12'),
-            array('setUserid', '12')
+            array('setUserid', '12'),
+            array('setOperation', 'UNKNOWN_OPERATION'),
         );
     }
 }

--- a/tests/Ogone/Tests/Ecommerce/EcommercePaymentRequestTest.php
+++ b/tests/Ogone/Tests/Ecommerce/EcommercePaymentRequestTest.php
@@ -105,7 +105,8 @@ class EcommercePaymentRequestTest extends \TestCase
 			array('setParamvar', $longString),
 			array('setPaymentMethod', 'Digital'),
 			array('setPspid', $longString),
+            array('setOperation', 'UNKNOWN_OPERATION'),
+            array('setOperation', EcommercePaymentRequest::OPERATION_REFUND),
 		);
 	}
-
 }

--- a/tests/Ogone/Tests/FormGenerator/SimpleFormGeneratorTest.php
+++ b/tests/Ogone/Tests/FormGenerator/SimpleFormGeneratorTest.php
@@ -69,4 +69,33 @@ class SimpleFormGeneratorTest extends \TestCase
         $this->assertXmlStringEqualsXmlString($expected, $formGenerator->render($paymentRequest));
         $this->assertXmlStringEqualsXmlString($expected, $formGenerator->render($paymentRequest, 'ogoneform', false));
     }
+
+	/** @test */
+	public function GeneratesAFormWithCustomOperationParameter()
+	{
+        $expected =
+            '<form method="post" action="https://secure.ogone.com/ncol/test/orderstandard_utf8.asp" id="ogone" name="ogone">
+                <input type="hidden" name="PSPID" value="123456789" />
+                <input type="hidden" name="ORDERID" value="987654321" />
+                <input type="hidden" name="CURRENCY" value="EUR" />
+                <input type="hidden" name="AMOUNT" value="100" />
+                <input type="hidden" name="CN" value="Louis XIV" />
+                <input type="hidden" name="OWNERADDRESS" value="1, Rue du Palais" />
+                <input type="hidden" name="OWNERTOWN" value="Versailles" />
+                <input type="hidden" name="OWNERZIP" value="2300" />
+                <input type="hidden" name="OWNERCTY" value="FR" />
+                <input type="hidden" name="EMAIL" value="louis.xiv@versailles.fr" />
+                <input type="hidden" name="OPERATION" value="SAL" />
+                <input type="hidden" name="'.PaymentRequest::SHASIGN_FIELD.'" value="foo" />
+                <input type="submit" value="Submit" id="ogonesubmit" name="ogonesubmit" />
+            </form>';
+
+        $paymentRequest = $this->provideMinimalPaymentRequest();
+        $paymentRequest->setOperation('SAL');
+
+        $formGenerator = new SimpleFormGenerator();
+
+        $this->assertXmlStringEqualsXmlString($expected, $formGenerator->render($paymentRequest));
+        $this->assertXmlStringEqualsXmlString($expected, $formGenerator->render($paymentRequest, 'ogone', true));
+	}
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -52,7 +52,6 @@ abstract class TestCase extends PHPUnit_Framework_TestCase
 	/** @return EcommercePaymentRequest*/
 	protected function provideCompletePaymentRequest()
 	{
-
 		$paymentRequest = $this->provideMinimalPaymentRequest();
 
 		$paymentRequest->setAccepturl('http://example.com/accept');
@@ -73,6 +72,8 @@ abstract class TestCase extends PHPUnit_Framework_TestCase
 		$paymentRequest->setOrderDescription("Four horses and a carriage");
 
 		$paymentRequest->setOwnerPhone('123456789');
+
+        $paymentRequest->setOperation(EcommercePaymentRequest::OPERATION_REQUEST_DIRECT_SALE);
 
 		return $paymentRequest;
 	}


### PR DESCRIPTION
Added support for optional 'operation' parameter for both e-Commerce and
DirectLink. Setting this parameter will overwrite any default value set
in account configuration page, as stated in the documentation:

http://payment-services.ingenico.com/int/en/ogone/support/guides/integration%20guides/directlink/request-a-new%20order#requestparameters
http://payment-services.ingenico.com/int/en/ogone/support/guides/integration%20guides/e-commerce/other-optional-fields